### PR TITLE
Implementing logging of nested resource events

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -638,9 +638,10 @@ class StackActions(object):
 
     def _child_stack_details(self):
         """
-        Returns a dict of StackName: {'RootId': '...', 'ParentId': '...''StackId': '...', 'StackName': '...', ...} as
-        defined by the AWS list-stacks call.  Unlike list-stacks, ParentId and RootId are always defined because this
-        method only returns child stacks where the RootId == self.stack.external_name.
+        Returns a dict of StackName: {'RootId': '...', 'ParentId': '...''StackId': '...',
+        'StackName': '...', ...} as defined by the AWS list-stacks call.  Unlike
+        list-stacks, ParentId and RootId are always defined because this method only returns
+        child stacks where the RootId == self.stack.external_name.
 
         :returns: A dict of stack name to stack details
         :rtype: dict
@@ -658,7 +659,9 @@ class StackActions(object):
         )
 
         root_id = root_stack['Stacks'][0]['StackId']
-        child_stacks = [(x['StackName'], x) for x in all_stacks['StackSummaries'] if x.get('RootId') == root_id]
+        child_stacks = [
+            (x['StackName'], x) for x in all_stacks['StackSummaries'] if x.get('RootId') == root_id
+        ]
         return OrderedDict(child_stacks)
 
     def _format_parameters(self, parameters):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -115,7 +115,7 @@ class TestStackActions(object):
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_create_sends_correct_request_no_notifications(
-            self, mock_wait_for_completion
+        self, mock_wait_for_completion
     ):
         self.actions.stack._template = Mock(spec=Template)
         self.actions.stack._template.get_boto_call_parameter.return_value = {
@@ -150,7 +150,7 @@ class TestStackActions(object):
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_create_sends_correct_request_with_no_failure_no_timeout(
-            self, mock_wait_for_completion
+        self, mock_wait_for_completion
     ):
         self.template._body = sentinel.template
         self.actions.stack.on_failure = None
@@ -662,7 +662,7 @@ class TestStackActions(object):
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_execute_change_set_sends_correct_request(
-            self, mock_wait_for_completion
+        self, mock_wait_for_completion
     ):
         self.actions.execute_change_set(sentinel.change_set_name)
         self.actions.connection_manager.call.assert_called_with(
@@ -987,7 +987,7 @@ class TestStackActions(object):
     @patch("sceptre.plan.actions.StackActions._child_stack_details")
     @patch("sceptre.plan.actions.StackActions._get_cs_status")
     def test_wait_for_cs_completion_calls_get_cs_status(
-            self, mock_get_cs_status, mock_child_stack_details
+        self, mock_get_cs_status, mock_child_stack_details
     ):
         mock_get_cs_status.side_effect = [
             StackChangeSetStatus.PENDING, StackChangeSetStatus.READY
@@ -999,7 +999,7 @@ class TestStackActions(object):
 
     @patch("sceptre.plan.actions.StackActions.describe_change_set")
     def test_get_cs_status_handles_all_statuses(
-            self, mock_describe_change_set
+        self, mock_describe_change_set
     ):
         scss = StackChangeSetStatus
         return_values = {                                                                                                     # NOQA
@@ -1051,7 +1051,7 @@ class TestStackActions(object):
 
     @patch("sceptre.plan.actions.StackActions.describe_change_set")
     def test_get_cs_status_raises_unexpected_exceptions(
-            self, mock_describe_change_set
+        self, mock_describe_change_set
     ):
         mock_describe_change_set.side_effect = ClientError(
             {

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -942,6 +942,48 @@ class TestStackActions(object):
         )
         self.actions._log_new_events()
 
+    @patch("sceptre.plan.actions.StackActions._describe")
+    @patch("sceptre.plan.actions.StackActions._child_stack_details")
+    @patch("sceptre.plan.actions.StackActions.describe_events")
+    def test_log_new_nested_events_prints_correct_event(self, mock_describe_events, mock_child_stack_details, mock_describe):
+        mock_describe_events.return_value = {
+            "StackEvents": [
+                {
+                    "Timestamp": datetime.datetime(
+                        2016, 3, 15, 14, 2, 0, 0, tzinfo=tzutc()
+                    ),
+                    "StackName": "id-2",
+                    "LogicalResourceId": "id-2",
+                    "StackId": "id-2",
+                    "ResourceType": "type-2",
+                    "ResourceStatus": "resource-status"
+                },
+                {
+                    "Timestamp": datetime.datetime(
+                        2016, 3, 15, 14, 1, 0, 0, tzinfo=tzutc()
+                    ),
+                    "StackName": "id-1",
+                    "LogicalResourceId": "id-1",
+                    "StackId": "id-1",
+                    "ResourceType": "type-1",
+                    "ResourceStatus": "resource",
+                    "ResourceStatusReason": "User Initiated"
+                }
+            ]
+        }
+        self.actions.stack.name = "stack-name"
+        mock_describe.return_value = {'Stacks': [{'StackId': "id-2"}]}
+        mock_child_stack_details.return_value = {
+            "id-2-substack-1": {
+                "StackName": "id-2-substack-1",
+                "RootId": "id-2"
+            }
+        }
+        self.actions.most_recent_event_datetime = (
+            datetime.datetime(2016, 3, 15, 14, 0, 0, 0, tzinfo=tzutc())
+        )
+        self.actions._log_new_events()
+
     @patch("sceptre.plan.actions.StackActions._child_stack_details")
     @patch("sceptre.plan.actions.StackActions._get_cs_status")
     def test_wait_for_cs_completion_calls_get_cs_status(


### PR DESCRIPTION
Adding logging of nested stack in Sceptre.

This PR gets all child stacks that have a RootId equal to one of the Stack IDs we are deploying.  It uses the same timestamp approach as Sceptre to avoid printing the same event more than once.

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [X] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes flake8 (`make lint`) checks.
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
